### PR TITLE
Update views_plugin_style.inc

### DIFF
--- a/core/modules/views/plugins/views_plugin_style.inc
+++ b/core/modules/views/plugins/views_plugin_style.inc
@@ -256,7 +256,7 @@ class views_plugin_style extends views_plugin {
       );
 
       if ($this->uses_fields()) {
-        $form['row_class']['#description'] .= ' ' . t('You may use field tokens from as per the "Replacement patterns" used in "Rewrite the output of this field" for all fields.');
+        $form['row_class']['#description'] .= ' ' . t('You may use field tokens from the "Replacement patterns" used in "Rewrite the output of this field" for all fields.');
       }
 
       $form['default_row_class'] = array(


### PR DESCRIPTION
Grammar error in Views display page style row class description text
Fixes issue: #5143

optimized the file by removing unexpected "as per".